### PR TITLE
feat: use newer adoptedStyleSheets API for programmatically changing/adding CSS

### DIFF
--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SAP Community CSS Modifier
 // @namespace    http://tampermonkey.net/
-// @version      v0.1.6
+// @version      v0.1.7
 // @description  Modify layout and styling on SAP Community pages
 // @author       Marian
 // @homepage     https://github.com/marianfoo/sap-community-css/blob/main/tampermonkey.js
@@ -16,12 +16,10 @@
 (function () {
   'use strict';
 
-  // Create a style element to hold the custom CSS
-  const style = document.createElement('style');
-  style.type = 'text/css';
-
-  // Insert the provided CSS into the style element
-  style.innerHTML = `
+   const style = new CSSStyleSheet();
+  
+   // insert the CSS into the stylesheet
+   style.replaceSync( `
         #boardmanagementtaplet {
             display: none !important;
         }
@@ -90,10 +88,10 @@
                 }
             }
         }
-    `;
+    `);
 
-  // Append the style element to the document header
-  document.head.appendChild(style);
+  // add the styles to the document
+  document.adoptedStyleSheets.push(style);
 
   // Think of the scene in Shaun Of The Dead when Philip, having turned
   // into a zombie in the car, and is still bothered by the loud music,


### PR DESCRIPTION
Hey Marian,

once I saw the Tampermonkey version (nice) I was thinking about adjusting this, so here it goes :)

- https://web.dev/articles/constructable-stylesheets
- https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets


![image](https://github.com/user-attachments/assets/1acd625f-7a0e-48e0-89ac-83a4de203712)
I would still understand if you'd be against this due to possible browser incompatibilities. 

Everything should work and stay the same. 

br :)

---

On another note: because this [here](https://github.com/marianfoo/sap-community-css/pull/1/files#diff-1404295c843a249920c49ba02f3e2445be854f054f7d4fd5f414f684be18807fR64-R72) was removed, I cannot differentiate granularly when the 'Answer' or 'Comment' button should be in the middle (question vs blog post). But, depending if that is wanted, I can add it back another way maybe. :)