### PR TITLE
style: update context menu style

### DIFF
--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -43,7 +43,7 @@
             .lia-user-search-results-list-container > .UserSearchItemContainer,
             .TkbPage .lia-tkb-article-entry {
                 width: 100% !important;
-                margin-top: -3%; /* offset back inline with avatar */
+                margin-top: -2%; /* offset back inline with avatar */
             }
         }
 

--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -43,7 +43,7 @@
             .lia-user-search-results-list-container > .UserSearchItemContainer,
             .TkbPage .lia-tkb-article-entry {
                 width: 100% !important;
-                margin-top: -4%; /* offset back inline with avatar */
+                margin-top: -3%; /* offset back inline with avatar */
             }
         }
 

--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -43,6 +43,7 @@
             .lia-user-search-results-list-container > .UserSearchItemContainer,
             .TkbPage .lia-tkb-article-entry {
                 width: 100% !important;
+                margin-top: -4%; /* offset back inline with avatar */
             }
         }
 

--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -67,9 +67,6 @@
         }
 
         .lia-quilt-column-alley.lia-quilt-column-alley-right {
-            display: flex;
-            justify-content: right;
-            flex-direction: row-reverse;
             font-size: small;
         }
 


### PR DESCRIPTION
With the addition of the newly added `Subscribe` button, the styling looks rather odd. I therefore removed one of the adjustments to let the bar flow more naturally again. 

Before:
![image](https://github.com/user-attachments/assets/472d9aca-ed99-49ce-8619-2323be61ffad)

After:
![image](https://github.com/user-attachments/assets/623f3526-52c6-456d-9416-0ea7947476e8)

**Edit, new After (Current)**: latest commits (with re-adjusted % negative margin)
![image](https://github.com/user-attachments/assets/5feae57c-3d26-4adf-b1c6-a4e64d482e84)

Original (no Tampermonkey):
![image](https://github.com/user-attachments/assets/d066ca48-363d-4dde-af2b-0e8697c298cb)

